### PR TITLE
Some fixes

### DIFF
--- a/sourcemapper.sh
+++ b/sourcemapper.sh
@@ -68,7 +68,7 @@ for ((i=0;i<=LENGTH;i++)); do
   F=$(echo $SOURCES | jq .[$i] | rev | awk -F'/' '{print $1}' | rev | sed 's/\"//g');
 
   # check for source in sourcesContent, otehrwise get directly from the URL.
-  DATA=$(echo $CONTENTS | jq .[$i])
+  DATA=$(echo $CONTENTS | jq .[$i] | cut --complement -c 1 | rev | cut --complement -c 1,2,3 | rev)
   if [ "$DATA" == 'null' ]; then
     DATA=$(curl -s "$URLNOMAP/$P/$F")
   fi

--- a/sourcemapper.sh
+++ b/sourcemapper.sh
@@ -67,8 +67,8 @@ for ((i=0;i<=LENGTH;i++)); do
   # get the filename without the path
   F=$(echo $SOURCES | jq .[$i] | rev | awk -F'/' '{print $1}' | rev | sed 's/\"//g');
 
-  # check for source in sourcesContent, otehrwise get directly from the URL.
-  DATA=$(echo $CONTENTS | jq .[$i] | cut --complement -c 1 | rev | cut --complement -c 1,2,3 | rev)
+  # check for source in sourcesContent, otherwise get directly from the URL.
+  DATA=$(echo $CONTENTS | jq .[$i])
   if [ "$DATA" == 'null' ]; then
     DATA=$(curl -s "$URLNOMAP/$P/$F")
   fi
@@ -79,7 +79,7 @@ for ((i=0;i<=LENGTH;i++)); do
   mkdir -p "$BASE/$P";
 
   # create the file at that location
-  echo -ne "$(echo $DATA | sed 's/%/%%/g')\n" > "$BASE/$P/$F";
+  echo -ne "$(echo $DATA | sed 's/%/%%/g' | cut --complement -c 1 | rev | cut --complement -c 1,2,3 | rev | sed 's/\\"/"/g')" > "$BASE/$P/$F";
   echo -ne "\rWriting: $BASE/$P/$F\n"
   ((COUNTER=COUNTER-1))
 

--- a/sourcemapper.sh
+++ b/sourcemapper.sh
@@ -23,6 +23,9 @@ if [ $(echo $URL | rev | awk -F'.' '{print $1}' | rev) != 'map' ]; then
   echo "Found reference to $URL"
 fi
 
+# disable wildcard expansion
+set -f
+
 # check if file exists at all
 RESP=$(curl -s -o /dev/null -w "%{http_code}" $URL)
 if [ "$RESP" != '200' ]; then


### PR DESCRIPTION
-Before it would expand `*` to the files in the working directory and mess up the output.
-Removes some unneccesary characters.
-Unescape double quoted strings. (might not work correctly nested strings, but it's an improvement)
-Files are now correctly placed in the base directory